### PR TITLE
✨ serialize card backs and extend Hand

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ This library offers a few VO classes to use inside Card-related applications:
 * `Rank`: represents the rank value of a Card, for example "A" or "7" ("T" is used for 10, to keep the same length).
 * `Suit`: represents the card suit, for example spades or diamonds.
 * `CardBack`: represents the back color of a card, for example red or blue. This allows distinguishing between multiple decks in games played with more than one deck.
+   Its `toText()`/`fromText()` methods map a back to a single character ("r" or "b"), used in string serialization.
 
 Some more classes, more elaborate, are available. They are abstract, and thus require a custom implementation to extend them:
 
@@ -105,6 +106,31 @@ $noBackAceOfSpades = new Card(Rank::Ace, Suit::Spades);
 $noBackAceOfSpades->isEqual($redAceOfSpades); // false
 $noBackAceOfSpades->isSameFace($redAceOfSpades); // true
 $noBackAceOfSpades->getBack(); // returns null
+```
+
+### Serializing cards with backs
+
+A card string can carry the back as an optional third character (`r` for red, `b` for blue).
+The default string form drops the back, to stay compatible with existing persisted data.
+Use `toString(withBack: true)` when the back must survive a round-trip:
+
+```php
+<?php
+
+require 'vendor/autoload.php';
+
+use Garak\Card\Card;
+
+$card = Card::fromRankSuit('Asr');
+$card->getBack(); // CardBack::Red
+
+echo $card;                           // will output "As"
+echo $card->toString(withBack: true); // will output "Asr"
+
+// The same applies to hands
+$hand = MyHand::createFromString('Asr,Kdb');
+echo $hand;                           // will output "As,Kd"
+echo $hand->toString(withBack: true); // will output "Asr,Kdb"
 ```
 
 ## Upgrading from version 0.8

--- a/src/Card.php
+++ b/src/Card.php
@@ -13,11 +13,19 @@ final readonly class Card implements \Stringable
     ) {
     }
 
+    /**
+     * Accepts a 2-char string (rank and suit, e.g. "As") or a 3-char string
+     * with a trailing back (e.g. "Asr" for an ace of spades with red back).
+     */
     public static function fromRankSuit(string $rankSuit): self
     {
-        [$value, $suit] = \str_split($rankSuit);
+        $length = \strlen($rankSuit);
+        if ($length < 2 || $length > 3) {
+            throw new \InvalidArgumentException(\sprintf('Invalid card string "%s": expected 2 or 3 characters.', $rankSuit));
+        }
+        $back = 3 === $length ? CardBack::fromText($rankSuit[2]) : null;
 
-        return new self(Rank::from($value), Suit::from($suit));
+        return new self(Rank::from($rankSuit[0]), Suit::from($rankSuit[1]), $back);
     }
 
     /**
@@ -51,7 +59,21 @@ final readonly class Card implements \Stringable
 
     public function __toString(): string
     {
-        return $this->rank->value.$this->suit->value;
+        return $this->toString();
+    }
+
+    /**
+     * String representation, parsable by fromRankSuit().
+     * The back (if any) is included only when explicitly requested.
+     */
+    public function toString(bool $withBack = false): string
+    {
+        $string = $this->rank->value.$this->suit->value;
+        if ($withBack && null !== $this->back) {
+            $string .= $this->back->toText();
+        }
+
+        return $string;
     }
 
     public function toText(): string

--- a/src/CardBack.php
+++ b/src/CardBack.php
@@ -7,6 +7,23 @@ enum CardBack: string
     case Red = 'red';
     case Blue = 'blue';
 
+    /**
+     * Single-char representation, used in string serialization (see Card::fromRankSuit()).
+     */
+    public function toText(): string
+    {
+        return match ($this) {
+            self::Red => 'r',
+            self::Blue => 'b',
+        };
+    }
+
+    public static function fromText(string $text): self
+    {
+        return \array_find(self::cases(), static fn (self $back): bool => $back->toText() === $text)
+            ?? throw new \ValueError(\sprintf('"%s" is not a valid back text for enum %s', $text, self::class));
+    }
+
     public function isEqual(self $back): bool
     {
         return $this === $back;

--- a/src/Hand.php
+++ b/src/Hand.php
@@ -7,7 +7,7 @@ namespace Garak\Card;
  * You must extend this class, and pass to constructor your anonymous functions to check starting
  * hand and to sort it.
  */
-abstract class Hand implements \Stringable
+abstract class Hand implements \Countable, \Stringable
 {
     /** @var array<int|string, Card> */
     protected array $cards;
@@ -55,7 +55,16 @@ abstract class Hand implements \Stringable
 
     public function __toString(): string
     {
-        return \implode(',', $this->cards);
+        return $this->toString();
+    }
+
+    /**
+     * String representation, parsable by createFromString().
+     * Backs (if any) are included only when explicitly requested.
+     */
+    public function toString(bool $withBack = false): string
+    {
+        return \implode(',', \array_map(static fn (Card $card): string => $card->toString($withBack), $this->cards));
     }
 
     public function toText(?Suit $trump = null): string
@@ -101,7 +110,24 @@ abstract class Hand implements \Stringable
 
     public static function isValid(string $cards): bool
     {
-        return 2 === \strlen($cards) || \strpos($cards, ',') > 0;
+        return \in_array(\strlen($cards), [2, 3], true) || \strpos($cards, ',') > 0;
+    }
+
+    public function has(Card $card): bool
+    {
+        return \array_any($this->cards, static fn (Card $c): bool => $card->isEqual($c));
+    }
+
+    /**
+     * Returns a new hand with the given card added.
+     * The sorting callback of the current hand is kept unless overridden.
+     */
+    public function add(Card $card, ?callable $sort = null): static
+    {
+        $cards = $this->cards;
+        $cards[] = $card;
+
+        return new static($cards, false, null, $sort ?? $this->sorting);
     }
 
     public function play(Card $card, ?callable $sort = null): static
@@ -111,12 +137,17 @@ abstract class Hand implements \Stringable
         $cards = $this->cards;
         unset($cards[$played]);
 
-        return new static($cards, false, null, $sort);
+        return new static($cards, false, null, $sort ?? $this->sorting);
     }
 
     public function isEmpty(): bool
     {
-        return 0 === \count($this->cards);
+        return 0 === $this->count();
+    }
+
+    public function count(): int
+    {
+        return \count($this->cards);
     }
 
     public function sort(?Suit $trump): void

--- a/tests/CardTest.php
+++ b/tests/CardTest.php
@@ -27,6 +27,44 @@ final class CardTest extends TestCase
     }
 
     #[Test]
+    public function constructFromStringWithBack(): void
+    {
+        $card = Card::fromRankSuit('Asr');
+        self::assertEquals(Rank::Ace, $card->getRank());
+        self::assertEquals(Suit::Spades, $card->getSuit());
+        self::assertEquals(CardBack::Red, $card->getBack());
+    }
+
+    #[Test]
+    public function constructFromStringWithoutBackHasNullBack(): void
+    {
+        self::assertNull(Card::fromRankSuit('As')->getBack());
+    }
+
+    #[Test]
+    public function constructFromStringRejectsTooShortString(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid card string "A": expected 2 or 3 characters.');
+        Card::fromRankSuit('A');
+    }
+
+    #[Test]
+    public function constructFromStringRejectsTooLongString(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid card string "Asrb": expected 2 or 3 characters.');
+        Card::fromRankSuit('Asrb');
+    }
+
+    #[Test]
+    public function constructFromStringRejectsUnknownBack(): void
+    {
+        $this->expectException(\ValueError::class);
+        Card::fromRankSuit('Asx');
+    }
+
+    #[Test]
     public function getDeck(): void
     {
         self::assertNotEmpty(Card::getDeck());
@@ -41,6 +79,37 @@ final class CardTest extends TestCase
     {
         $card = new Card(Rank::Five, Suit::Clubs);
         self::assertEquals('5c', (string) $card);
+    }
+
+    #[Test]
+    public function toStringDropsBackByDefault(): void
+    {
+        $card = new Card(Rank::Ace, Suit::Spades, CardBack::Red);
+        self::assertEquals('As', (string) $card);
+        self::assertEquals('As', $card->toString());
+    }
+
+    #[Test]
+    public function toStringWithBack(): void
+    {
+        $card = new Card(Rank::Ace, Suit::Spades, CardBack::Blue);
+        self::assertEquals('Asb', $card->toString(true));
+    }
+
+    #[Test]
+    public function toStringWithBackOnCardWithoutBack(): void
+    {
+        $card = new Card(Rank::Ace, Suit::Spades);
+        self::assertEquals('As', $card->toString(true));
+    }
+
+    #[Test]
+    public function stringRoundTripKeepsBack(): void
+    {
+        $card = new Card(Rank::Ten, Suit::Hearts, CardBack::Red);
+        $parsed = Card::fromRankSuit($card->toString(true));
+        self::assertTrue($card->isEqual($parsed));
+        self::assertEquals(CardBack::Red, $parsed->getBack());
     }
 
     #[Test]

--- a/tests/HandTest.php
+++ b/tests/HandTest.php
@@ -35,6 +35,30 @@ final class HandTest extends TestCase
     }
 
     #[Test]
+    public function handStringRepresentationDropsBacksByDefault(): void
+    {
+        $hand = HandStub::createFromString('Asr,Kdb,7c', false);
+        self::assertEquals('As,Kd,7c', (string) $hand);
+        self::assertEquals('As,Kd,7c', $hand->toString());
+    }
+
+    #[Test]
+    public function handStringRepresentationWithBacks(): void
+    {
+        $hand = HandStub::createFromString('Asr,Kdb,7c', false);
+        self::assertEquals('Asr,Kdb,7c', $hand->toString(true));
+    }
+
+    #[Test]
+    public function handStringRoundTripKeepsBacks(): void
+    {
+        $hand = HandStub::createFromString('Asr,Kdb', false);
+        $parsed = HandStub::createFromString($hand->toString(true), false);
+        self::assertEquals(CardBack::Red, $parsed->getCards()[0]->getBack());
+        self::assertEquals(CardBack::Blue, $parsed->getCards()[1]->getBack());
+    }
+
+    #[Test]
     public function handTextRepresentation(): void
     {
         $hand = HandStub::createFromString('6s,4h,3s,Td,6c,3d,3h,Kc,Qc,Tc,7d,2c,6d', true, self::getCheck());
@@ -53,7 +77,10 @@ final class HandTest extends TestCase
     {
         self::assertTrue(HandStub::isValid('6s'));
         self::assertTrue(HandStub::isValid('6s,4h,3s'));
+        self::assertTrue(HandStub::isValid('6sr'));
+        self::assertTrue(HandStub::isValid('6sr,4hb'));
         self::assertFalse(HandStub::isValid('6'));
+        self::assertFalse(HandStub::isValid('6sr4'));
     }
 
     #[Test]
@@ -82,6 +109,85 @@ final class HandTest extends TestCase
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Card As not present in hand (As).');
         $hand->play(new Card(Rank::Ace, Suit::Spades, CardBack::Blue));
+    }
+
+    #[Test]
+    public function countCards(): void
+    {
+        $hand = HandStub::createFromString('6s,4h,3s', false);
+        self::assertSame(3, $hand->count());
+        self::assertCount(3, $hand);
+        self::assertCount(0, new HandStub([], false));
+    }
+
+    #[Test]
+    public function hasCard(): void
+    {
+        $hand = HandStub::createFromString('6s,4h,3s', false);
+        self::assertTrue($hand->has(Card::fromRankSuit('4h')));
+        self::assertFalse($hand->has(Card::fromRankSuit('5d')));
+    }
+
+    #[Test]
+    public function hasCardDistinguishesBacks(): void
+    {
+        $hand = HandStub::createFromString('Asr', false);
+        self::assertTrue($hand->has(Card::fromRankSuit('Asr')));
+        self::assertFalse($hand->has(Card::fromRankSuit('Asb')));
+        self::assertFalse($hand->has(Card::fromRankSuit('As')));
+    }
+
+    #[Test]
+    public function addCardReturnsNewHand(): void
+    {
+        $hand = HandStub::createFromString('6s,4h', false);
+        $added = $hand->add(Card::fromRankSuit('3s'));
+
+        self::assertNotSame($hand, $added);
+        self::assertEquals('6s,4h,3s', (string) $added);
+        self::assertCount(3, $added);
+        self::assertEquals('6s,4h', (string) $hand);
+        self::assertCount(2, $hand);
+    }
+
+    #[Test]
+    public function addCardKeepsSorting(): void
+    {
+        $calls = 0;
+        $sort = static function () use (&$calls): void { ++$calls; };
+        $hand = HandStub::createFromString('6s,4h', false, null, $sort);
+
+        $added = $hand->add(Card::fromRankSuit('3s'));
+        $added->sort(null);
+
+        self::assertSame(1, $calls);
+    }
+
+    #[Test]
+    public function addCardWithSortingOverride(): void
+    {
+        $original = 0;
+        $override = 0;
+        $hand = HandStub::createFromString('6s,4h', false, null, static function () use (&$original): void { ++$original; });
+
+        $added = $hand->add(Card::fromRankSuit('3s'), static function () use (&$override): void { ++$override; });
+        $added->sort(null);
+
+        self::assertSame(0, $original);
+        self::assertSame(1, $override);
+    }
+
+    #[Test]
+    public function playCardKeepsSorting(): void
+    {
+        $calls = 0;
+        $sort = static function () use (&$calls): void { ++$calls; };
+        $hand = HandStub::createFromString('6s,4h', false, null, $sort);
+
+        $played = $hand->play(Card::fromRankSuit('6s'));
+        $played->sort(null);
+
+        self::assertSame(1, $calls);
     }
 
     #[Test]


### PR DESCRIPTION
- Card::fromRankSuit() accepts an optional 3rd char for the back ("Asr")
- Card/Hand::toString(withBack) preserves the back; __toString() still drops it
- CardBack::toText()/fromText() map backs to single chars
- Hand implements Countable, adds has() and add()